### PR TITLE
Fixing the performance problem of the expression parser

### DIFF
--- a/src/Text/Parser/Expression.hs
+++ b/src/Text/Parser/Expression.hs
@@ -112,12 +112,10 @@ buildExpressionParser operators simpleExpr
               ambiguousLeft     = ambiguous "left" lassocOp
               ambiguousNon      = ambiguous "non" nassocOp
 
-              preTermP   =     try (do { pre <- prefixP; x <- term; return $ pre x })
-                           <|> term
-
-              termP      = do { x <- preTermP
+              termP      = do { pre <- prefixP
+                              ; x <- term
                               ; post <- postfixP
-                              ; return (post x)
+                              ; return (post (pre x))
                               }
 
               postfixP   = postfixOp <|> return id


### PR DESCRIPTION
This patch basically mimics what is done in Parsec. Without this change,
Text.Parser.Expression is about 120 times slower than Text.Parsec.Expr.
