### PR TITLE
Fix char escape bug

### DIFF
--- a/src/Text/Parser/Token.hs
+++ b/src/Text/Parser/Token.hs
@@ -549,7 +549,7 @@ charLetter = satisfy (\c -> (c /= '\'') && (c /= '\\') && (c > '\026'))
 escapeCode :: TokenParsing m => m Char
 escapeCode = (charEsc <|> charNum <|> charAscii <|> charControl) <?> "escape code"
   where
-  charControl = (\c -> toEnum (fromEnum c - fromEnum 'A')) <$> (char '^' *> upper)
+  charControl = (\c -> toEnum (fromEnum c - fromEnum '@')) <$> (char '^' *> (upper <|> char '@'))
   charNum     = toEnum . fromInteger <$> num where
     num = decimal
       <|> (char 'o' *> number 8 octDigit)


### PR DESCRIPTION
E.g., '^A' is supposed to be '\1', not '\0'. (Also, '\0' is '^@'.)

Parsec has this bug too, FWIW (maybe that's why it's here?), but it seems everyone else forgot about it...
