### PR TITLE
Upped 'transformers' version constraint to include 0.4.*

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -53,7 +53,7 @@ library
     parsec               >= 3.1     && < 3.2,
     attoparsec           >= 0.11.2  && < 0.12,
     text                 >= 0.10    && < 1.2,
-    transformers         >= 0.2     && < 0.4,
+    transformers         >= 0.2     && < 0.5,
     unordered-containers >= 0.2     && < 0.3
 
 -- Verify the results of the examples


### PR DESCRIPTION
Tested in a sandbox with `cabal install --only-dependencies --constraint "transformers>=0.4"` and configure+build. Please upload a point release on Hackage.

Thanks.
