### PR TITLE
Fix `notFollowedBy` for parsers for which `<|>` backtracks

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -63,10 +63,30 @@ test-suite doctests
   default-language: Haskell2010
   build-depends:
     base,
+    bytestring,
     containers,
     directory >= 1.0,
     doctest >= 0.9.1,
-    filepath
+    filepath,
+    QuickCheck,
+    quickcheck-instances
+  ghc-options: -Wall -threaded
+  if impl(ghc<7.6.1)
+    ghc-options: -Werror
+  hs-source-dirs: tests
+
+test-suite quickcheck
+  type:    exitcode-stdio-1.0
+  main-is: QuickCheck.hs
+  default-language: Haskell2010
+  build-depends:
+    attoparsec,
+    base == 4.*,
+    bytestring,
+    parsec >= 3,
+    parsers,
+    QuickCheck,
+    quickcheck-instances
   ghc-options: -Wall -threaded
   if impl(ghc<7.6.1)
     ghc-options: -Werror

--- a/src/Text/Parser/Char.hs
+++ b/src/Text/Parser/Char.hs
@@ -223,7 +223,7 @@ class Parsing m => CharParsing m where
   text t = t <$ string (unpack t)
   {-# INLINE text #-}
 
-instance (CharParsing m, MonadPlus m) => CharParsing (Lazy.StateT s m) where
+instance (CharParsing m, MonadPlus m, Show s) => CharParsing (Lazy.StateT s m) where
   satisfy = lift . satisfy
   {-# INLINE satisfy #-}
   char    = lift . char
@@ -237,7 +237,7 @@ instance (CharParsing m, MonadPlus m) => CharParsing (Lazy.StateT s m) where
   text = lift . text
   {-# INLINE text #-}
 
-instance (CharParsing m, MonadPlus m) => CharParsing (Strict.StateT s m) where
+instance (CharParsing m, MonadPlus m, Show s) => CharParsing (Strict.StateT s m) where
   satisfy = lift . satisfy
   {-# INLINE satisfy #-}
   char    = lift . char
@@ -265,7 +265,7 @@ instance (CharParsing m, MonadPlus m) => CharParsing (ReaderT e m) where
   text = lift . text
   {-# INLINE text #-}
 
-instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Strict.WriterT w m) where
+instance (CharParsing m, MonadPlus m, Monoid w, Show w) => CharParsing (Strict.WriterT w m) where
   satisfy = lift . satisfy
   {-# INLINE satisfy #-}
   char    = lift . char
@@ -279,7 +279,7 @@ instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Strict.WriterT w
   text = lift . text
   {-# INLINE text #-}
 
-instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Lazy.WriterT w m) where
+instance (CharParsing m, MonadPlus m, Monoid w, Show w) => CharParsing (Lazy.WriterT w m) where
   satisfy = lift . satisfy
   {-# INLINE satisfy #-}
   char    = lift . char
@@ -293,7 +293,7 @@ instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Lazy.WriterT w m
   text = lift . text
   {-# INLINE text #-}
 
-instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Lazy.RWST r w s m) where
+instance (CharParsing m, MonadPlus m, Monoid w, Show w, Show s) => CharParsing (Lazy.RWST r w s m) where
   satisfy = lift . satisfy
   {-# INLINE satisfy #-}
   char    = lift . char
@@ -307,7 +307,7 @@ instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Lazy.RWST r w s 
   text = lift . text
   {-# INLINE text #-}
 
-instance (CharParsing m, MonadPlus m, Monoid w) => CharParsing (Strict.RWST r w s m) where
+instance (CharParsing m, MonadPlus m, Monoid w, Show w, Show s) => CharParsing (Strict.RWST r w s m) where
   satisfy = lift . satisfy
   {-# INLINE satisfy #-}
   char    = lift . char

--- a/src/Text/Parser/LookAhead.hs
+++ b/src/Text/Parser/LookAhead.hs
@@ -46,11 +46,11 @@ class Parsing m => LookAheadParsing m where
   -- | @lookAhead p@ parses @p@ without consuming any input.
   lookAhead :: m a -> m a
 
-instance (LookAheadParsing m, MonadPlus m) => LookAheadParsing (Lazy.StateT s m) where
+instance (LookAheadParsing m, MonadPlus m, Show s) => LookAheadParsing (Lazy.StateT s m) where
   lookAhead (Lazy.StateT m) = Lazy.StateT $ lookAhead . m
   {-# INLINE lookAhead #-}
 
-instance (LookAheadParsing m, MonadPlus m) => LookAheadParsing (Strict.StateT s m) where
+instance (LookAheadParsing m, MonadPlus m, Show s) => LookAheadParsing (Strict.StateT s m) where
   lookAhead (Strict.StateT m) = Strict.StateT $ lookAhead . m
   {-# INLINE lookAhead #-}
 
@@ -58,19 +58,19 @@ instance (LookAheadParsing m, MonadPlus m) => LookAheadParsing (ReaderT e m) whe
   lookAhead (ReaderT m) = ReaderT $ lookAhead . m
   {-# INLINE lookAhead #-}
 
-instance (LookAheadParsing m, MonadPlus m, Monoid w) => LookAheadParsing (Strict.WriterT w m) where
+instance (LookAheadParsing m, MonadPlus m, Monoid w, Show w) => LookAheadParsing (Strict.WriterT w m) where
   lookAhead (Strict.WriterT m) = Strict.WriterT $ lookAhead m
   {-# INLINE lookAhead #-}
 
-instance (LookAheadParsing m, MonadPlus m, Monoid w) => LookAheadParsing (Lazy.WriterT w m) where
+instance (LookAheadParsing m, MonadPlus m, Monoid w, Show w) => LookAheadParsing (Lazy.WriterT w m) where
   lookAhead (Lazy.WriterT m) = Lazy.WriterT $ lookAhead m
   {-# INLINE lookAhead #-}
 
-instance (LookAheadParsing m, MonadPlus m, Monoid w) => LookAheadParsing (Lazy.RWST r w s m) where
+instance (LookAheadParsing m, MonadPlus m, Monoid w, Show w, Show s) => LookAheadParsing (Lazy.RWST r w s m) where
   lookAhead (Lazy.RWST m) = Lazy.RWST $ \r s -> lookAhead (m r s)
   {-# INLINE lookAhead #-}
 
-instance (LookAheadParsing m, MonadPlus m, Monoid w) => LookAheadParsing (Strict.RWST r w s m) where
+instance (LookAheadParsing m, MonadPlus m, Monoid w, Show w, Show s) => LookAheadParsing (Strict.RWST r w s m) where
   lookAhead (Strict.RWST m) = Strict.RWST $ \r s -> lookAhead (m r s)
   {-# INLINE lookAhead #-}
 

--- a/src/Text/Parser/Token.hs
+++ b/src/Text/Parser/Token.hs
@@ -344,7 +344,7 @@ class CharParsing m => TokenParsing m where
   token :: m a -> m a
   token p = p <* (someSpace <|> pure ())
 
-instance (TokenParsing m, MonadPlus m) => TokenParsing (Lazy.StateT s m) where
+instance (TokenParsing m, MonadPlus m, Show s) => TokenParsing (Lazy.StateT s m) where
   nesting (Lazy.StateT m) = Lazy.StateT $ nesting . m
   {-# INLINE nesting #-}
   someSpace = lift someSpace
@@ -354,7 +354,7 @@ instance (TokenParsing m, MonadPlus m) => TokenParsing (Lazy.StateT s m) where
   highlight h (Lazy.StateT m) = Lazy.StateT $ highlight h . m
   {-# INLINE highlight #-}
 
-instance (TokenParsing m, MonadPlus m) => TokenParsing (Strict.StateT s m) where
+instance (TokenParsing m, MonadPlus m, Show s) => TokenParsing (Strict.StateT s m) where
   nesting (Strict.StateT m) = Strict.StateT $ nesting . m
   {-# INLINE nesting #-}
   someSpace = lift someSpace
@@ -374,7 +374,7 @@ instance (TokenParsing m, MonadPlus m) => TokenParsing (ReaderT e m) where
   highlight h (ReaderT m) = ReaderT $ highlight h . m
   {-# INLINE highlight #-}
 
-instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Strict.WriterT w m) where
+instance (TokenParsing m, MonadPlus m, Monoid w, Show w) => TokenParsing (Strict.WriterT w m) where
   nesting (Strict.WriterT m) = Strict.WriterT $ nesting m
   {-# INLINE nesting #-}
   someSpace = lift someSpace
@@ -384,7 +384,7 @@ instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Strict.WriterT
   highlight h (Strict.WriterT m) = Strict.WriterT $ highlight h m
   {-# INLINE highlight #-}
 
-instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Lazy.WriterT w m) where
+instance (TokenParsing m, MonadPlus m, Monoid w, Show w) => TokenParsing (Lazy.WriterT w m) where
   nesting (Lazy.WriterT m) = Lazy.WriterT $ nesting m
   {-# INLINE nesting #-}
   someSpace = lift someSpace
@@ -394,7 +394,7 @@ instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Lazy.WriterT w
   highlight h (Lazy.WriterT m) = Lazy.WriterT $ highlight h m
   {-# INLINE highlight #-}
 
-instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Lazy.RWST r w s m) where
+instance (TokenParsing m, MonadPlus m, Monoid w, Show w, Show s) => TokenParsing (Lazy.RWST r w s m) where
   nesting (Lazy.RWST m) = Lazy.RWST $ \r s -> nesting (m r s)
   {-# INLINE nesting #-}
   someSpace = lift someSpace
@@ -404,7 +404,7 @@ instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Lazy.RWST r w 
   highlight h (Lazy.RWST m) = Lazy.RWST $ \r s -> highlight h (m r s)
   {-# INLINE highlight #-}
 
-instance (TokenParsing m, MonadPlus m, Monoid w) => TokenParsing (Strict.RWST r w s m) where
+instance (TokenParsing m, MonadPlus m, Monoid w, Show w, Show s) => TokenParsing (Strict.RWST r w s m) where
   nesting (Strict.RWST m) = Strict.RWST $ \r s -> nesting (m r s)
   {-# INLINE nesting #-}
   someSpace = lift someSpace
@@ -683,6 +683,9 @@ instance Parsing m => Parsing (Unhighlighted m) where
   {-# INLINE unexpected #-}
   eof = Unhighlighted eof
   {-# INLINE eof #-}
+  notFollowedBy (Unhighlighted m) = Unhighlighted $ notFollowedBy m
+  {-# INLINE notFollowedBy #-}
+
 
 instance MonadTrans Unhighlighted where
   lift = Unhighlighted
@@ -712,6 +715,8 @@ instance Parsing m => Parsing (Unspaced m) where
   {-# INLINE unexpected #-}
   eof = Unspaced eof
   {-# INLINE eof #-}
+  notFollowedBy (Unspaced m) = Unspaced $ notFollowedBy m
+  {-# INLINE notFollowedBy #-}
 
 instance MonadTrans Unspaced where
   lift = Unspaced
@@ -741,6 +746,8 @@ instance Parsing m => Parsing (Unlined m) where
   {-# INLINE unexpected #-}
   eof = Unlined eof
   {-# INLINE eof #-}
+  notFollowedBy (Unlined m) = Unlined $ notFollowedBy m
+  {-# INLINE notFollowedBy #-}
 
 instance MonadTrans Unlined where
   lift = Unlined

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
+
+module Main
+( main
+) where
+
+import Control.Applicative
+
+import Data.Attoparsec.ByteString.Char8 (parseOnly)
+import qualified Data.ByteString.Char8 as B8
+
+#if MIN_VERSION_base(4,7,0)
+import Data.Either
+#endif
+
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+
+import Text.Parsec.Prim as P (parse)
+import Text.Parser.Char
+import Text.Parser.Combinators
+import Text.ParserCombinators.ReadP (readP_to_S)
+
+-- -------------------------------------------------------------------------- --
+-- Run tests with different parser frameworks
+
+-- Instead of letting quick check pick the parser framework as a test parameter
+-- it may be better to just run all tests for each parser framework.
+
+data P a = P ((Monad m, CharParsing m) => m a)
+
+data TestParser a = TestParser String (P a -> String -> Either String a)
+
+instance Show (TestParser a) where show (TestParser n _) = n
+
+pAtto, pParsec, pReadP :: TestParser a
+pAtto = TestParser "attoparsec" $ \(P p) -> parseOnly p . B8.pack
+pParsec = TestParser "parsec" $ \(P p) -> either (Left . show) Right . parse p "test input"
+pReadP = TestParser "ReadP" $ \(P p) s -> case readP_to_S p s of
+  [] -> Left "parseFailed"
+  (a,_):_ -> Right a
+
+instance Arbitrary (TestParser a) where
+    arbitrary = elements [pReadP, pAtto, pParsec]
+
+-- -------------------------------------------------------------------------- --
+-- Main
+
+main :: IO ()
+main = mapM_ quickCheck tests
+
+-- -------------------------------------------------------------------------- --
+-- Tests
+
+tests :: [Property]
+tests =
+    [ property prop_notFollowedBy0
+    , property prop_notFollowedBy1
+    , property prop_notFollowedBy2
+    , property prop_notFollowedBy3
+    ]
+
+-- -------------------------------------------------------------------------- --
+-- Properties
+
+prop_notFollowedBy0 :: TestParser Char -> Char -> Char -> Bool
+prop_notFollowedBy0 (TestParser _ p) x y = either (\_ -> x == y) (/= y)
+    $ p (P (notFollowedBy (char y) *> anyChar)) [x]
+
+prop_notFollowedBy1 :: TestParser Char -> Char -> Bool
+prop_notFollowedBy1 (TestParser _ p) x = either (\_ -> x == x) (/= x)
+    $ p (P (notFollowedBy (char x) *> anyChar)) [x]
+
+prop_notFollowedBy2 :: TestParser Char -> String -> Char -> Bool
+prop_notFollowedBy2 (TestParser _ p) x y = isLeft
+    $ p (P (anyChar *> notFollowedBy (char y) *> char y)) x
+
+prop_notFollowedBy3 :: TestParser () -> Char -> Bool
+prop_notFollowedBy3 (TestParser _ p) x = isRight
+    $ p (P (notFollowedBy (char x) <|> char x *> pure ())) [x]
+
+-- -------------------------------------------------------------------------- --
+-- Utils
+
+#if !MIN_VERSION_base(4,7,0)
+isLeft :: Either a b -> Bool
+isLeft = either (const True) (const False)
+
+isRight :: Either a b -> Bool
+isRight = either (const False) (const True)
+#endif


### PR DESCRIPTION
The Alternative instances for Parsec, Attoparsec, and ReadP 
behave all different:

Parsec: non-backtracking and non-commutative
Attoparsec: backtracking and  non-commutative
ReadP: backtracking and commutative

The current default implementation is correct only for a non-backtracking
and commutative behavior of `<|>`. Ironically, the Parsing instance for
Parsec provides its own implementation of notFollowedBy whereas
Attoparsec and ReadP use the default implementation which does
not behave correctly for these.

This patch provides implementations of `notFollowedBy` for Attoparsec 
and ReadP. Due to the lack of an explicit non-commutative choice by 
means of primitives from the Parsing class there is no default implementation
that would work for all parsing frameworks. Therefor the default
implementation is removed by this patch. Due to this removal `Show`
constraints are required for the state parameters of the `Parsing` instances 
for `StateT`, `WriteT`, and `RWST`.
