### PR TITLE
Bump text upper version bounds

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -52,7 +52,7 @@ library
     containers           >= 0.4     && < 0.6,
     parsec               >= 3.1     && < 3.2,
     attoparsec           >= 0.12.1  && < 0.13,
-    text                 >= 0.10    && < 1.2,
+    text                 >= 0.10    && < 1.3,
     transformers         >= 0.2     && < 0.5,
     unordered-containers >= 0.2     && < 0.3
 


### PR DESCRIPTION
Allow `parsers` to use `text-1.2.0.0`.
