### PR TITLE
Implements token parsers for Scientific values

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -54,6 +54,7 @@ library
     attoparsec           >= 0.12.1  && < 0.13,
     text                 >= 0.10    && < 1.3,
     transformers         >= 0.2     && < 0.5,
+    scientific           >= 0.3     && < 0.4,
     unordered-containers >= 0.2     && < 0.3
 
 -- Verify the results of the examples


### PR DESCRIPTION
It introduces three new parsers: scientific,
naturalOrScientific and integerOrScientifc, that
behave just like their "Double" counterparts, but
without losing precision.

This was also suggested in #33.
