### PR TITLE
Import ReadP instances from base-orphans

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -48,6 +48,7 @@ library
 
   build-depends:
     base                 >= 4       && < 5,
+    base-orphans         >= 0.3     && < 1,
     charset              >= 0.3     && < 1,
     containers           >= 0.4     && < 0.6,
     parsec               >= 3.1     && < 3.2,

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -57,11 +57,7 @@ module Text.Parser.Combinators
   ) where
 
 import Control.Applicative
-#ifdef ORPHAN_ALTERNATIVE_READP
-import Control.Monad (MonadPlus(..), ap)
-#else
 import Control.Monad (MonadPlus(..))
-#endif
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.State.Lazy as Lazy
 import Control.Monad.Trans.State.Strict as Strict
@@ -73,6 +69,9 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Identity
 import Data.Foldable (asum)
 import Data.Monoid
+#ifdef ORPHAN_ALTERNATIVE_READP
+import Data.Orphans ()
+#endif
 import Data.Traversable (sequenceA)
 import qualified Text.Parsec as Parsec
 import qualified Data.Attoparsec.Types as Att
@@ -411,14 +410,3 @@ instance Parsing ReadP.ReadP where
   eof        = ReadP.eof
   notFollowedBy p = ((Just <$> p) ReadP.<++ pure Nothing)
     >>= maybe (pure ()) (unexpected . show)
-
-#ifdef ORPHAN_ALTERNATIVE_READP
-instance Applicative ReadP.ReadP where
-  pure = return
-  (<*>) = ap
-
-instance Alternative ReadP.ReadP where
-  empty = mzero
-  (<|>) = mplus
-#endif
-


### PR DESCRIPTION
Consolidates `parsers`' orphan `Applicative ReadP` and `Alternative ReadP` instances with the ones defined in `base-orphans`.