### PR TITLE
Add LookAheadParsing instance for attoparsec

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -47,15 +47,15 @@ library
   ghc-options: -O2
 
   build-depends:
-    base                 >= 4       && < 5,
-    charset              >= 0.3     && < 1,
-    containers           >= 0.4     && < 0.6,
-    parsec               >= 3.1     && < 3.2,
-    attoparsec           >= 0.12.1  && < 0.14,
-    text                 >= 0.10    && < 1.3,
-    transformers         >= 0.2     && < 0.5,
-    scientific           >= 0.3     && < 0.4,
-    unordered-containers >= 0.2     && < 0.3
+    base                 >= 4        && < 5,
+    charset              >= 0.3      && < 1,
+    containers           >= 0.4      && < 0.6,
+    parsec               >= 3.1      && < 3.2,
+    attoparsec           >= 0.12.1.4 && < 0.14,
+    text                 >= 0.10     && < 1.3,
+    transformers         >= 0.2      && < 0.5,
+    scientific           >= 0.3      && < 0.4,
+    unordered-containers >= 0.2      && < 0.3
 
 -- Verify the results of the examples
 test-suite doctests

--- a/src/Text/Parser/LookAhead.hs
+++ b/src/Text/Parser/LookAhead.hs
@@ -36,6 +36,8 @@ import Control.Monad.Trans.RWS.Lazy as Lazy
 import Control.Monad.Trans.RWS.Strict as Strict
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Identity
+import qualified Data.Attoparsec.Types as Att
+import qualified Data.Attoparsec.Combinator as Att
 import Data.Monoid
 import qualified Text.ParserCombinators.ReadP as ReadP
 import qualified Text.Parsec as Parsec
@@ -80,6 +82,9 @@ instance (LookAheadParsing m, Monad m) => LookAheadParsing (IdentityT m) where
 
 instance (Parsec.Stream s m t, Show t) => LookAheadParsing (Parsec.ParsecT s u m) where
   lookAhead = Parsec.lookAhead
+
+instance Att.Chunk i => LookAheadParsing (Att.Parser i) where
+  lookAhead = Att.lookAhead
 
 instance LookAheadParsing ReadP.ReadP where
   lookAhead p = ReadP.look >>= \s ->


### PR DESCRIPTION
Also raises the lower bound for attoparsec from `0.12.1` to `0.12.1.4`.