### PR TITLE
Make default signatures agree with method signatures

### DIFF
--- a/src/Text/Parser/Char.hs
+++ b/src/Text/Parser/Char.hs
@@ -183,7 +183,7 @@ class Parsing m => CharParsing m where
 #ifdef USE_DEFAULT_SIGNATURES
   default satisfy :: (MonadTrans t, CharParsing n, Monad n, m ~ t n) =>
                      (Char -> Bool) ->
-                     t n Char
+                     m Char
   satisfy = lift . satisfy
 #endif
   -- | @char c@ parses a single character @c@. Returns the parsed

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -252,7 +252,7 @@ class Alternative m => Parsing m where
   unexpected :: String -> m a
 #ifdef USE_DEFAULT_SIGNATURES
   default unexpected :: (MonadTrans t, Monad n, Parsing n, m ~ t n) =>
-                        String -> t n a
+                        String -> m a
   unexpected = lift . unexpected
   {-# INLINE unexpected #-}
 #endif
@@ -263,7 +263,7 @@ class Alternative m => Parsing m where
   -- >  eof  = notFollowedBy anyChar <?> "end of input"
   eof :: m ()
 #ifdef USE_DEFAULT_SIGNATURES
-  default eof :: (MonadTrans t, Monad n, Parsing n, m ~ t n) => t n ()
+  default eof :: (MonadTrans t, Monad n, Parsing n, m ~ t n) => m ()
   eof = lift eof
   {-# INLINE eof #-}
 #endif


### PR DESCRIPTION
This allows compilation with GHC 8.2, which now checks for compatibility.