### PR TITLE
Add sepByNonEmpty and sepEndByNonEmpty

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -59,7 +59,7 @@ library
     base-orphans         >= 0.3      && < 1,
     charset              >= 0.3      && < 1,
     containers           >= 0.4      && < 0.6,
-    semigroups           >= 0.8      && < 1,
+    semigroups           >= 0.12     && < 1,
     parsec               >= 3.1      && < 3.2,
     attoparsec           >= 0.12.1.4 && < 0.14,
     text                 >= 0.10     && < 1.3,

--- a/parsers.cabal
+++ b/parsers.cabal
@@ -59,6 +59,7 @@ library
     base-orphans         >= 0.3      && < 1,
     charset              >= 0.3      && < 1,
     containers           >= 0.4      && < 0.6,
+    semigroups           >= 0.8      && < 1,
     parsec               >= 3.1      && < 3.2,
     attoparsec           >= 0.12.1.4 && < 0.14,
     text                 >= 0.10     && < 1.3,

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -42,7 +42,9 @@ module Text.Parser.Combinators
   , many     -- from Control.Applicative
   , sepBy
   , sepBy1
+  , sepByNonEmpty
   , sepEndBy1
+  , sepEndByNonEmpty
   , sepEndBy
   , endBy1
   , endBy
@@ -68,6 +70,7 @@ import Control.Monad.Trans.RWS.Strict as Strict
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Identity
 import Data.Foldable (asum)
+import Data.List.NonEmpty
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
 #ifdef ORPHAN_ALTERNATIVE_READP
@@ -125,11 +128,23 @@ sepBy1 :: Alternative m => m a -> m sep -> m [a]
 sepBy1 p sep = (:) <$> p <*> many (sep *> p)
 {-# INLINE sepBy1 #-}
 
+-- | @sepByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
+-- by @sep@. Returns a non-empty list of values returned by @p@.
+sepByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
+sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
+{-# INLINE sepByNonEmpty #-}
+
 -- | @sepEndBy1 p sep@ parses /one/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@. Returns a list of values
 -- returned by @p@.
 sepEndBy1 :: Alternative m => m a -> m sep -> m [a]
 sepEndBy1 p sep = (:) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])
+
+-- | @sepEndByNonEmpty p sep@ parses /one/ or more occurrences of @p@,
+-- separated and optionally ended by @sep@. Returns a non-empty of values
+-- returned by @p@.
+sepEndByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
+sepEndByNonEmpty p sep = (:|) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])
 
 -- | @sepEndBy p sep@ parses /zero/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@, ie. haskell style

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -142,7 +142,7 @@ sepEndBy1 :: Alternative m => m a -> m sep -> m [a]
 sepEndBy1 p sep = toList <$> sepEndByNonEmpty p sep
 
 -- | @sepEndByNonEmpty p sep@ parses /one/ or more occurrences of @p@,
--- separated and optionally ended by @sep@. Returns a non-empty of values
+-- separated and optionally ended by @sep@. Returns a non-empty list of values
 -- returned by @p@.
 sepEndByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
 sepEndByNonEmpty p sep = (:|) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -47,6 +47,7 @@ module Text.Parser.Combinators
   , sepEndByNonEmpty
   , sepEndBy
   , endBy1
+  , endByNonEmpty
   , endBy
   , count
   , chainl
@@ -160,6 +161,12 @@ sepEndBy p sep = sepEndBy1 p sep <|> pure []
 endBy1 :: Alternative m => m a -> m sep -> m [a]
 endBy1 p sep = some (p <* sep)
 {-# INLINE endBy1 #-}
+
+-- | @endByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
+-- and ended by @sep@. Returns a non-empty list of values returned by @p@.
+endByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
+endByNonEmpty p sep = some1 (p <* sep)
+{-# INLINE endByNonEmpty #-}
 
 -- | @endBy p sep@ parses /zero/ or more occurrences of @p@, separated
 -- and ended by @sep@. Returns a list of values returned by @p@.

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -125,7 +125,7 @@ sepBy p sep = sepBy1 p sep <|> pure []
 -- | @sepBy1 p sep@ parses /one/ or more occurrences of @p@, separated
 -- by @sep@. Returns a list of values returned by @p@.
 sepBy1 :: Alternative m => m a -> m sep -> m [a]
-sepBy1 p sep = (:) <$> p <*> many (sep *> p)
+sepBy1 p sep = toList <$> sepByNonEmpty p sep
 {-# INLINE sepBy1 #-}
 
 -- | @sepByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
@@ -138,7 +138,7 @@ sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
 -- separated and optionally ended by @sep@. Returns a list of values
 -- returned by @p@.
 sepEndBy1 :: Alternative m => m a -> m sep -> m [a]
-sepEndBy1 p sep = (:) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])
+sepEndBy1 p sep = toList <$> sepEndByNonEmpty p sep
 
 -- | @sepEndByNonEmpty p sep@ parses /one/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@. Returns a non-empty of values


### PR DESCRIPTION
Some points for discussion:

- How did I do with the `semigroups` bounds? I"m still getting used to putting the right bounds on things
- `sepBy1` could now be defined in terms of `sepByNonEmpty` and `toList`. Should I do that? Same question for `sepByEnd1`.
- there could be a NonEmpty version of `endBy1` too, but `endBy1` is defined in terms of `some` from `Alternative`, which returns a list. Is there a version of `some` somewhere which returns NonEmpty? If not I could just define it inline to define endByNonEmpty.