### PR TITLE
Add `surBy` shortcut for `between` the same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 .cabal-sandbox
 cabal.sandbox.config
 docs

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -38,6 +38,7 @@ module Text.Parser.Combinators
   , optional -- from Control.Applicative, parsec optionMaybe
   , skipOptional -- parsec optional
   , between
+  , surBy
   , some     -- from Control.Applicative, parsec many1
   , many     -- from Control.Applicative
   , sepBy
@@ -114,6 +115,12 @@ skipOptional p = (() <$ p) <|> pure ()
 between :: Applicative m => m bra -> m ket -> m a -> m a
 between bra ket p = bra *> p <* ket
 {-# INLINE between #-}
+
+-- | @p \`surBy\` f@ is @p@ surrounded by @f@. Shortcut for @between f f p@.
+-- As in @between@, returns the value returned by @p@.
+surBy :: Applicative m => m a -> m sur -> m a
+surBy p bound = between bound bound p
+{-# INLINE surBy #-}
 
 -- | @sepBy p sep@ parses /zero/ or more occurrences of @p@, separated
 -- by @sep@. Returns a list of values returned by @p@.


### PR DESCRIPTION
Add `surBy` as a shortcut for `between bra ket` when `bra` and `ket` are the same.

Not sure about the naming though.