### PR TITLE
Make attoparsec and parsec dependencies optional

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -44,6 +44,16 @@ flag binary
   description:
     You can disable the use of the `binary` package using `-f-binary`.
 
+flag parsec
+  default: True
+  description:
+    You can disable the use of the `parsec` package using `-f-parsec`.
+
+flag attoparsec
+  default: True
+  description:
+    You can disable the use of the `attoparsec` package using `-f-attoparsec`.
+
 library
   default-language: Haskell2010
   exposed-modules:
@@ -68,8 +78,6 @@ library
     charset              >= 0.3      && < 1,
     containers           >= 0.4      && < 0.7,
     semigroups           >= 0.12     && < 1,
-    parsec               >= 3.1      && < 3.2,
-    attoparsec           >= 0.12.1.4 && < 0.14,
     text                 >= 0.10     && < 1.3,
     transformers         >= 0.2      && < 0.6,
     mtl                  >= 2.0.1    && < 2.3,
@@ -77,19 +85,26 @@ library
     unordered-containers >= 0.2      && < 0.3
 
   if flag(binary)
-    build-depends: binary >= 0.7.2 && < 1
+    build-depends: binary     >= 0.7.2    && < 1
+  if flag(parsec)
+    build-depends: parsec     >= 3.1      && < 3.2
+  if flag(attoparsec)
+    build-depends: attoparsec >= 0.12.1.4 && < 0.14
 
 test-suite quickcheck
   type:    exitcode-stdio-1.0
   main-is: QuickCheck.hs
   default-language: Haskell2010
   build-depends:
-    attoparsec,
     base == 4.*,
     bytestring,
-    parsec >= 3,
     parsers,
     QuickCheck,
     quickcheck-instances
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
+
+  if flag(parsec)
+    build-depends: parsec >= 3
+  if flag(attoparsec)
+    build-depends: attoparsec

--- a/src/Text/Parser/Char.hs
+++ b/src/Text/Parser/Char.hs
@@ -69,10 +69,16 @@ import Data.Monoid
 #endif
 import Data.Text
 import qualified Text.ParserCombinators.ReadP as ReadP
+import Text.Parser.Combinators
+
+#ifdef MIN_VERSION_parsec
 import qualified Text.Parsec as Parsec
+#endif
+
+#ifdef MIN_VERSION_attoparsec
 import qualified Data.Attoparsec.Types as Att
 import qualified Data.Attoparsec.Combinator as Att
-import Text.Parser.Combinators
+#endif
 
 -- | @oneOf cs@ succeeds if the current character is in the supplied
 -- list of characters @cs@. Returns the parsed character. See also
@@ -339,17 +345,21 @@ instance (CharParsing m, MonadPlus m) => CharParsing (IdentityT m) where
   text = lift . text
   {-# INLINE text #-}
 
+#ifdef MIN_VERSION_parsec
 instance Parsec.Stream s m Char => CharParsing (Parsec.ParsecT s u m) where
   satisfy   = Parsec.satisfy
   char      = Parsec.char
   notChar c = Parsec.satisfy (/= c)
   anyChar   = Parsec.anyChar
   string    = Parsec.string
+#endif
 
+#ifdef MIN_VERSION_attoparsec
 instance Att.Chunk t => CharParsing (Att.Parser t) where
   satisfy p = fmap e2c $ Att.satisfyElem $ p . e2c
     where e2c = Att.chunkElemToChar (undefined :: t)
   {-# INLINE satisfy #-}
+#endif
 
 instance CharParsing ReadP.ReadP where
   satisfy   = ReadP.satisfy

--- a/src/Text/Parser/Combinators.hs
+++ b/src/Text/Parser/Combinators.hs
@@ -80,9 +80,16 @@ import Data.Orphans ()
 #endif
 import Data.Traversable (sequenceA)
 #endif
+
+#ifdef MIN_VERSION_parsec
 import qualified Text.Parsec as Parsec
+#endif
+
+#ifdef MIN_VERSION_attoparsec
 import qualified Data.Attoparsec.Types as Att
 import qualified Data.Attoparsec.Combinator as Att
+#endif 
+
 import qualified Text.ParserCombinators.ReadP as ReadP
 
 #ifdef MIN_VERSION_binary
@@ -419,6 +426,7 @@ instance (Parsing m, Monad m) => Parsing (IdentityT m) where
   notFollowedBy (IdentityT m) = IdentityT $ notFollowedBy m
   {-# INLINE notFollowedBy #-}
 
+#ifdef MIN_VERSION_parsec
 instance (Parsec.Stream s m t, Show t) => Parsing (Parsec.ParsecT s u m) where
   try           = Parsec.try
   (<?>)         = (Parsec.<?>)
@@ -427,7 +435,9 @@ instance (Parsec.Stream s m t, Show t) => Parsing (Parsec.ParsecT s u m) where
   unexpected    = Parsec.unexpected
   eof           = Parsec.eof
   notFollowedBy = Parsec.notFollowedBy
+#endif
 
+#ifdef MIN_VERSION_attoparsec
 instance Att.Chunk t => Parsing (Att.Parser t) where
   try             = Att.try
   (<?>)           = (Att.<?>)
@@ -436,6 +446,7 @@ instance Att.Chunk t => Parsing (Att.Parser t) where
   unexpected      = fail
   eof             = Att.endOfInput
   notFollowedBy p = optional p >>= maybe (pure ()) (unexpected . show)
+#endif 
 
 #ifdef MIN_VERSION_binary
 instance Parsing B.Get where

--- a/src/Text/Parser/LookAhead.hs
+++ b/src/Text/Parser/LookAhead.hs
@@ -36,14 +36,20 @@ import Control.Monad.Trans.RWS.Lazy as Lazy
 import Control.Monad.Trans.RWS.Strict as Strict
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Identity
-import qualified Data.Attoparsec.Types as Att
-import qualified Data.Attoparsec.Combinator as Att
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
 #endif
 import qualified Text.ParserCombinators.ReadP as ReadP
-import qualified Text.Parsec as Parsec
 import Text.Parser.Combinators
+
+#ifdef MIN_VERSION_parsec
+import qualified Text.Parsec as Parsec
+#endif
+
+#ifdef MIN_VERSION_attoparsec
+import qualified Data.Attoparsec.Types as Att
+import qualified Data.Attoparsec.Combinator as Att
+#endif
 
 #ifdef MIN_VERSION_binary
 import qualified Data.Binary.Get as B
@@ -86,11 +92,15 @@ instance (LookAheadParsing m, Monad m) => LookAheadParsing (IdentityT m) where
   lookAhead = IdentityT . lookAhead . runIdentityT
   {-# INLINE lookAhead #-}
 
+#ifdef MIN_VERSION_parsec
 instance (Parsec.Stream s m t, Show t) => LookAheadParsing (Parsec.ParsecT s u m) where
   lookAhead = Parsec.lookAhead
+#endif
 
+#ifdef MIN_VERSION_attoparsec
 instance Att.Chunk i => LookAheadParsing (Att.Parser i) where
   lookAhead = Att.lookAhead
+#endif
 
 #ifdef MIN_VERSION_binary
 instance LookAheadParsing B.Get where

--- a/src/Text/Parser/Token.hs
+++ b/src/Text/Parser/Token.hs
@@ -113,11 +113,17 @@ import Data.String
 import Data.Text hiding (empty,zip,foldl',take,map,length,splitAt,null,transpose)
 import Numeric (showIntAtBase)
 import qualified Text.ParserCombinators.ReadP as ReadP
-import qualified Text.Parsec as Parsec
-import qualified Data.Attoparsec.Types as Att
 import Text.Parser.Char
 import Text.Parser.Combinators
 import Text.Parser.Token.Highlight
+
+#ifdef MIN_VERSION_parsec
+import qualified Text.Parsec as Parsec
+#endif
+
+#ifdef MIN_VERSION_attoparsec
+import qualified Data.Attoparsec.Types as Att
+#endif
 
 -- | Skip zero or more bytes worth of white space. More complex parsers are
 -- free to consider comments as white space.
@@ -925,8 +931,12 @@ instance TokenParsing m => TokenParsing (Unlined m) where
   highlight h (Unlined m) = Unlined (highlight h m)
   {-# INLINE highlight #-}
 
+#ifdef MIN_VERSION_parsec
 instance Parsec.Stream s m Char => TokenParsing (Parsec.ParsecT s u m)
+#endif
 
+#ifdef MIN_VERSION_attoparsec
 instance Att.Chunk t => TokenParsing (Att.Parser t)
+#endif
 
 instance TokenParsing ReadP.ReadP


### PR DESCRIPTION
It seems silly to force everyone who uses a parser combinator library that uses this library to have two others as transitive dependencies.

I know that parsec is bundled with GHC now, but it's not like it was much effort to do just for symmetry.