### PR TITLE
Added the Text.Parser.Input module

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -55,11 +55,17 @@ flag attoparsec
   description:
     You can disable the use of the `attoparsec` package using `-f-attoparsec`.
 
+flag monoid-subclasses
+  default: True
+  description:
+    You can disable the use of the `monoid-subclasses` package using `-f-monoid-subclasses`.
+
 library
   default-language: Haskell2010
   exposed-modules:
     Text.Parser.Char
     Text.Parser.Combinators
+    Text.Parser.Input
     Text.Parser.LookAhead
     Text.Parser.Permutation
     Text.Parser.Expression
@@ -92,7 +98,9 @@ library
   if flag(parsec)
     build-depends: parsec     >= 3.1      && < 3.2
   if flag(attoparsec)
-    build-depends: attoparsec >= 0.12.1.4 && < 0.14
+    build-depends: attoparsec >= 0.12.1.4 && < 0.14, bytestring >= 0.9 && < 0.11, text >= 0.1 && < 1.3
+  if flag(monoid-subclasses)
+    build-depends: base >= 4.9, monoid-subclasses >= 1.0 && < 1.1
 
 test-suite quickcheck
   type:    exitcode-stdio-1.0

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 #ifdef MIN_VERSION_monoid_subclasses
 {-# LANGUAGE DefaultSignatures #-}

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -20,9 +20,11 @@
 
 module Text.Parser.Input where
 
-import Control.Applicative (Alternative ((<|>)))
+import Control.Applicative (Applicative ((<*>)), Alternative ((<|>)))
 import Control.Monad (void)
+import Data.Functor ((<$>))
 import qualified Data.List as List
+import Data.Monoid (Monoid, mappend, mempty)
 import Data.String (IsString (fromString))
 import Text.ParserCombinators.ReadP (ReadP)
 import qualified Text.ParserCombinators.ReadP as ReadP
@@ -179,7 +181,7 @@ instance InputParsing ReadP where
       where scanList l = [(prefix' [], suffix' [])]
                where (prefix', suffix', _, _) = List.foldl' g (id, id, state, True) l
                      g (prefix, suffix, s1, live) x
-                        | live, Just s2 <- f s1 [x] = seq s2 $ (prefix . (x:), id, s2, True)
+                        | live, Just s2 <- f s1 [x] = seq s2 (prefix . (x:), id, s2, True)
                         | otherwise = (prefix, suffix . (x:), s1, False)
    takeWhile predicate = ReadP.readS_to_P ((:[]) . List.span (predicate . (:[])))
    takeWhile1 predicate = do x <- takeWhile predicate
@@ -194,7 +196,7 @@ instance InputCharParsing ReadP where
       where scanList l = [(prefix' [], suffix' [])]
                where (prefix', suffix', _, _) = List.foldl' g (id, id, state, True) l
                      g (prefix, suffix, s1, live) c
-                        | live, Just s2 <- f s1 c = seq s2 $ (prefix . (c:), id, s2, True)
+                        | live, Just s2 <- f s1 c = seq s2 (prefix . (c:), id, s2, True)
                         | otherwise = (prefix, suffix . (c:), s1, False)
    takeCharsWhile predicate = ReadP.readS_to_P ((:[]) . List.span predicate)
    takeCharsWhile1 predicate = do x <- takeCharsWhile predicate

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -20,7 +20,7 @@
 
 module Text.Parser.Input where
 
-import Control.Applicative (Applicative ((<*>)), Alternative ((<|>)))
+import Control.Applicative (Applicative ((<*>), pure), Alternative ((<|>)))
 import Control.Monad (void)
 import Data.Functor ((<$>))
 import qualified Data.List as List

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
-#if __GLASGOW_HASKELL__ < 810
+#if defined (__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 802
 {-# LANGUAGE TypeSynonymInstances #-}
 #endif
 

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+
+#ifdef MIN_VERSION_monoid_subclasses
+{-# LANGUAGE DefaultSignatures #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -102,7 +105,6 @@ class LookAheadParsing m => InputParsing m where
 
    anyToken = take 1
    notSatisfy predicate = try (void $ satisfy $ not . predicate) <|> eof
-   default concatMany :: (Monoid a, Alternative m) => m a -> m a
    concatMany p = go
       where go = mappend <$> try p <*> go <|> pure mempty
 
@@ -150,8 +152,6 @@ class (CharParsing m, InputParsing m) => InputCharParsing m where
    -- that match the given predicate; an optimized version of @fmap fromString  . some . Char.satisfy@.
    takeCharsWhile1 :: (Char -> Bool) -> m (ParserInput m)
 
-   default satisfyCharInput :: IsString (ParserInput m) => (Char -> Bool) -> m (ParserInput m)
-   satisfyCharInput = fmap (fromString . (:[])) . Char.satisfy
    notSatisfyChar = notFollowedBy . Char.satisfy
 
 #ifdef MIN_VERSION_monoid_subclasses

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-#if defined(MIN_VERSION_monoid_subclasses) && __GLASGOW_HASKELL__ < 810
+#ifdef MIN_VERSION_monoid_subclasses
 {-# LANGUAGE DefaultSignatures #-}
 #endif
 

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-#ifdef MIN_VERSION_monoid_subclasses
+#if defined(MIN_VERSION_monoid_subclasses) && __GLASGOW_HASKELL__ < 810
 {-# LANGUAGE DefaultSignatures #-}
 #endif
 

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Text.Parser.Char
+-- Copyright   :  (c) Edward Kmett 2020
+-- License     :  BSD3
+--
+-- Maintainer  :  ekmett@gmail.com
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Parsers for monoidal input streams
+--
+-----------------------------------------------------------------------------
+
+module Text.Parser.Input where
+
+import Control.Applicative (Alternative ((<|>)))
+import Control.Monad (void)
+import Data.String (IsString (fromString))
+import Text.ParserCombinators.ReadP (ReadP)
+import qualified Text.ParserCombinators.ReadP as ReadP
+
+import Text.Parser.Char (CharParsing)
+import Text.Parser.Combinators (count, eof, notFollowedBy, try, unexpected)
+import Text.Parser.LookAhead (LookAheadParsing, lookAhead)
+import qualified Text.Parser.Char as Char
+
+#ifdef MIN_VERSION_monoid_subclasses
+import qualified Data.Monoid.Factorial as Factorial
+import qualified Data.Monoid.Null as Null
+import qualified Data.Monoid.Textual as Textual
+import qualified Data.Semigroup.Cancellative as Cancellative
+import Data.Monoid.Factorial (FactorialMonoid)
+import Data.Monoid.Textual (TextualMonoid)
+import Data.Semigroup.Cancellative (LeftReductive)
+#endif
+
+#ifdef MIN_VERSION_attoparsec
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as ByteString.Char8
+import qualified Data.Text as Text
+
+import qualified Data.Attoparsec.ByteString as Attoparsec
+import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec.Char8
+import qualified Data.Attoparsec.Text as Attoparsec.Text
+#endif
+
+import Prelude hiding (take, takeWhile)
+
+-- | Methods for parsing factorial monoid inputs
+class LookAheadParsing m => InputParsing m where
+   type ParserInput m
+   -- | Always sucessful parser that returns the remaining input without consuming it.
+   getInput :: m (ParserInput m)
+
+   -- | A parser that accepts any single atomic prefix of the input stream.
+   -- > anyToken == satisfy (const True)
+   -- > anyToken == take 1
+   anyToken :: m (ParserInput m)
+   -- | A parser that accepts exactly the given number of input atoms.
+   take :: Int -> m (ParserInput m)
+   -- | A parser that accepts an input atom only if it satisfies the given predicate.
+   satisfy :: (ParserInput m -> Bool) -> m (ParserInput m)
+   -- | A parser that succeeds exactly when satisfy doesn't, equivalent to
+   -- 'Text.Parser.Combinators.notFollowedBy' @. satisfy@
+   notSatisfy :: (ParserInput m -> Bool) -> m ()
+
+   -- | A stateful scanner. The predicate modifies a state argument, and each transformed state is passed to successive
+   -- invocations of the predicate on each token of the input until one returns 'Nothing' or the input ends.
+   --
+   -- This parser does not fail.  It will return an empty string if the predicate returns 'Nothing' on the first
+   -- character.
+   --
+   -- /Note/: Because this parser does not fail, do not use it with combinators such as 'many', because such parsers
+   -- loop until a failure occurs.  Careless use will thus result in an infinite loop.
+   scan :: state -> (state -> ParserInput m -> Maybe state) -> m (ParserInput m)
+   -- | A parser that consumes and returns the given prefix of the input.
+   string :: ParserInput m -> m (ParserInput m)
+
+   -- | A parser accepting the longest sequence of input atoms that match the given predicate; an optimized version of
+   -- 'concatMany . satisfy'.
+   --
+   -- /Note/: Because this parser does not fail, do not use it with combinators such as 'many', because such parsers
+   -- loop until a failure occurs.  Careless use will thus result in an infinite loop.
+   takeWhile :: (ParserInput m -> Bool) -> m (ParserInput m)
+   -- | A parser accepting the longest non-empty sequence of input atoms that match the given predicate; an optimized
+   -- version of 'concatSome . satisfy'.
+   takeWhile1 :: (ParserInput m -> Bool) -> m (ParserInput m)
+   -- | Zero or more argument occurrences like 'many', with concatenated monoidal results.
+   concatMany :: Monoid a => m a -> m a
+
+   anyToken = take 1
+   notSatisfy predicate = try (void $ satisfy $ not . predicate) <|> eof
+   default concatMany :: (Monoid a, Alternative m) => m a -> m a
+   concatMany p = go
+      where go = mappend <$> try p <*> go <|> pure mempty
+
+#ifdef MIN_VERSION_monoid_subclasses
+   default string :: (Monad m, LeftReductive (ParserInput m), FactorialMonoid (ParserInput m), Show (ParserInput m))
+                  => ParserInput m -> m (ParserInput m)
+   string s = do i <- getInput
+                 if s `Cancellative.isPrefixOf` i
+                    then take (Factorial.length s)
+                    else unexpected ("string " <> show s)
+   default scan :: (Monad m, FactorialMonoid (ParserInput m)) =>
+                   state -> (state -> ParserInput m -> Maybe state) -> m (ParserInput m)
+   scan state f = do i <- getInput
+                     let (prefix, _suffix, _state) = Factorial.spanMaybe' state f i
+                     take (Factorial.length prefix)
+   default takeWhile :: (Monad m, FactorialMonoid (ParserInput m)) => (ParserInput m -> Bool) -> m (ParserInput m)
+   takeWhile predicate = do i <- getInput
+                            take (Factorial.length $ Factorial.takeWhile predicate i)
+   default takeWhile1 :: (Monad m, FactorialMonoid (ParserInput m)) => (ParserInput m -> Bool) -> m (ParserInput m)
+   takeWhile1 predicate = do x <- takeWhile predicate
+                             if Null.null x then unexpected "takeWhile1" else pure x
+#endif
+   {-# INLINE concatMany #-}
+
+
+-- | Methods for parsing textual monoid inputs
+class (CharParsing m, InputParsing m) => InputCharParsing m where
+   -- | Specialization of 'satisfy' on textual inputs, accepting an input character only if it satisfies the given
+   -- predicate, and returning the input atom that represents the character. Equivalent to @fmap singleton
+   -- . Char.satisfy@
+   satisfyCharInput :: (Char -> Bool) -> m (ParserInput m)
+   -- | A parser that succeeds exactly when satisfy doesn't, equivalent to @notFollowedBy . Char.satisfy@
+   notSatisfyChar :: (Char -> Bool) -> m ()
+
+   -- | Stateful scanner like `scan`, but specialized for 'TextualMonoid' inputs.
+   scanChars :: state -> (state -> Char -> Maybe state) -> m (ParserInput m)
+
+   -- | Specialization of 'takeWhile' on 'TextualMonoid' inputs, accepting the longest sequence of input characters that
+   -- match the given predicate; an optimized version of @fmap fromString  . many . Char.satisfy@.
+   --
+   -- /Note/: Because this parser does not fail, do not use it with combinators such as 'many', because such parsers
+   -- loop until a failure occurs.  Careless use will thus result in an infinite loop.
+   takeCharsWhile :: (Char -> Bool) -> m (ParserInput m)
+   -- | Specialization of 'takeWhile1' on 'TextualMonoid' inputs, accepting the longest sequence of input characters
+   -- that match the given predicate; an optimized version of @fmap fromString  . some . Char.satisfy@.
+   takeCharsWhile1 :: (Char -> Bool) -> m (ParserInput m)
+
+   default satisfyCharInput :: IsString (ParserInput m) => (Char -> Bool) -> m (ParserInput m)
+   satisfyCharInput = fmap (fromString . (:[])) . Char.satisfy
+   notSatisfyChar = notFollowedBy . Char.satisfy
+   default scanChars :: (Monad m, TextualMonoid (ParserInput m)) =>
+                        state -> (state -> Char -> Maybe state) -> m (ParserInput m)
+   scanChars state f = do i <- getInput
+                          let (prefix, _suffix, _state) = Textual.spanMaybe' state (const $ const Nothing) f i
+                          take (Factorial.length prefix)
+
+#ifdef MIN_VERSION_monoid_subclasses
+   default takeCharsWhile :: (Monad m, TextualMonoid (ParserInput m)) => (Char -> Bool) -> m (ParserInput m)
+   takeCharsWhile predicate = do i <- getInput
+                                 take (Factorial.length $ Textual.takeWhile_ False predicate i)
+   default takeCharsWhile1 :: (Monad m, TextualMonoid (ParserInput m)) => (Char -> Bool) -> m (ParserInput m)
+   takeCharsWhile1 predicate = do x <- takeCharsWhile predicate
+                                  if Null.null x then unexpected "takeCharsWhile1" else pure x
+#endif
+
+instance InputParsing ReadP where
+   type ParserInput ReadP = String
+   getInput = ReadP.look
+   take n = count n ReadP.get
+   anyToken = pure <$> ReadP.get
+   satisfy predicate = pure <$> ReadP.satisfy (predicate . pure)
+   string = ReadP.string
+
+instance InputCharParsing ReadP where
+   satisfyCharInput predicate = pure <$> ReadP.satisfy predicate
+
+#ifdef MIN_VERSION_attoparsec
+instance InputParsing Attoparsec.Parser where
+   type ParserInput Attoparsec.Parser = ByteString
+   getInput = lookAhead Attoparsec.takeByteString
+   anyToken = Attoparsec.take 1
+   take = Attoparsec.take
+   satisfy predicate = Attoparsec.satisfyWith ByteString.singleton predicate
+   string = Attoparsec.string
+
+instance InputCharParsing Attoparsec.Parser where
+   satisfyCharInput predicate = ByteString.Char8.singleton <$> Attoparsec.Char8.satisfy predicate
+   scanChars = Attoparsec.Char8.scan
+   takeCharsWhile = Attoparsec.Char8.takeWhile
+   takeCharsWhile1 = Attoparsec.Char8.takeWhile1
+
+instance InputParsing Attoparsec.Text.Parser where
+   type ParserInput Attoparsec.Text.Parser = Text
+   getInput = lookAhead Attoparsec.Text.takeText
+   anyToken = Attoparsec.Text.take 1
+   take = Attoparsec.Text.take
+   satisfy predicate = Attoparsec.Text.satisfyWith Text.singleton predicate
+   string = Attoparsec.Text.string
+
+instance InputCharParsing Attoparsec.Text.Parser where
+   satisfyCharInput predicate = Text.singleton <$> Attoparsec.Text.satisfy predicate
+   scanChars = Attoparsec.Text.scan
+   takeCharsWhile = Attoparsec.Text.takeWhile
+   takeCharsWhile1 = Attoparsec.Text.takeWhile1
+#endif

--- a/src/Text/Parser/Input.hs
+++ b/src/Text/Parser/Input.hs
@@ -2,7 +2,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+
+#if __GLASGOW_HASKELL__ < 810
 {-# LANGUAGE TypeSynonymInstances #-}
+#endif
 
 #ifdef MIN_VERSION_monoid_subclasses
 {-# LANGUAGE DefaultSignatures #-}


### PR DESCRIPTION
I wonder if you'd be open to adding another module to the library, with a couple of classes for efficient parsing of arbitrary monoidal inputs? I've used variations of these classes in grammatical-parsers, but that package would be a heavy dependency and I feel this would be a better home for them. If not, I'll probably resort to creating yet another small package.

I'd be happy to add more instances and tests if the module is acceptable.
