### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/parsers.cabal
+++ b/parsers.cabal
@@ -81,7 +81,6 @@ library
     base-orphans         >= 0.3      && < 1,
     charset              >= 0.3      && < 1,
     containers           >= 0.4      && < 0.7,
-    semigroups           >= 0.12     && < 1,
     text                 >= 0.10     && < 1.3,
     transformers         >= 0.2      && < 0.6,
     mtl                  >= 2.0.1    && < 2.3,
@@ -94,6 +93,8 @@ library
     build-depends: parsec     >= 3.1      && < 3.2
   if flag(attoparsec)
     build-depends: attoparsec >= 0.12.1.4 && < 0.14
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.12     && < 1
 
 test-suite quickcheck
   type:    exitcode-stdio-1.0


### PR DESCRIPTION
They are not needed on newer GHC.